### PR TITLE
add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]  
+> This repo has been archived in favor of [NabuCasa/pycognito](https://github.com/NabuCasa/pycognito/).
+
+
 ![alt text](https://s3.amazonaws.com/capless/images/warrant-small.png "Warrant - Serverless Authentication")
 
 # Warrant


### PR DESCRIPTION
### Motivation
We internally recently switched from this fork to the community-maintained [NabuCasa/pycognito](https://github.com/NabuCasa/pycognito/), which means that this fork is no longer needed.

### Changes
This PR adds an archive notice to the main README of the repo, referring users to [NabuCasa/pycognito](https://github.com/NabuCasa/pycognito/). After merging this PR we can officially archive this repo.